### PR TITLE
Renamed Events to include the "Event" Suffix in the Name.

### DIFF
--- a/app/Events/Backend/Access/Role/RoleCreatedEvent.php
+++ b/app/Events/Backend/Access/Role/RoleCreatedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\Role;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class RoleUpdated.
+ * Class RoleCreatedEvent.
  */
-class RoleUpdated
+class RoleCreatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/Role/RoleDeletedEvent.php
+++ b/app/Events/Backend/Access/Role/RoleDeletedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\Role;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class RoleDeleted.
+ * Class RoleDeletedEvent.
  */
-class RoleDeleted
+class RoleDeletedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/Role/RoleUpdatedEvent.php
+++ b/app/Events/Backend/Access/Role/RoleUpdatedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\Role;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class RoleCreated.
+ * Class RoleUpdatedEvent.
  */
-class RoleCreated
+class RoleUpdatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserCreatedEvent.php
+++ b/app/Events/Backend/Access/User/UserCreatedEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Frontend\Auth;
+namespace App\Events\Backend\Access\User;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserLoggedOut.
+ * Class UserCreatedEvent.
  */
-class UserLoggedOut
+class UserCreatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserDeactivatedEvent.php
+++ b/app/Events/Backend/Access/User/UserDeactivatedEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Frontend\Auth;
+namespace App\Events\Backend\Access\User;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserRegistered.
+ * Class UserDeactivatedEvent.
  */
-class UserRegistered
+class UserDeactivatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserDeletedEvent.php
+++ b/app/Events/Backend/Access/User/UserDeletedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserDeactivated.
+ * Class UserDeletedEvent.
  */
-class UserDeactivated
+class UserDeletedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserPasswordChangedEvent.php
+++ b/app/Events/Backend/Access/User/UserPasswordChangedEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Frontend\Auth;
+namespace App\Events\Backend\Access\User;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserLoggedIn.
+ * Class UserPasswordChangedEvent.
  */
-class UserLoggedIn
+class UserPasswordChangedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserPermanentlyDeletedEvent.php
+++ b/app/Events/Backend/Access/User/UserPermanentlyDeletedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserRestored.
+ * Class UserPermanentlyDeletedEvent.
  */
-class UserRestored
+class UserPermanentlyDeletedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserReactivatedEvent.php
+++ b/app/Events/Backend/Access/User/UserReactivatedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserUpdated.
+ * Class UserReactivatedEvent.
  */
-class UserUpdated
+class UserReactivatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserRestoredEvent.php
+++ b/app/Events/Backend/Access/User/UserRestoredEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserPermanentlyDeleted.
+ * Class UserRestoredEvent.
  */
-class UserPermanentlyDeleted
+class UserRestoredEvent
 {
     use SerializesModels;
 

--- a/app/Events/Backend/Access/User/UserUpdatedEvent.php
+++ b/app/Events/Backend/Access/User/UserUpdatedEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Backend\Access\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserPasswordChanged.
+ * Class UserUpdatedEvent.
  */
-class UserPasswordChanged
+class UserUpdatedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Frontend/Auth/UserEmailConfirmedEvent.php
+++ b/app/Events/Frontend/Auth/UserEmailConfirmedEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Backend\Access\User;
+namespace App\Events\Frontend\Auth;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserReactivated.
+ * Class UserEmailConfirmedEvent.
  */
-class UserReactivated
+class UserEmailConfirmedEvent
 {
     use SerializesModels;
 

--- a/app/Events/Frontend/Auth/UserLoggedInEvent.php
+++ b/app/Events/Frontend/Auth/UserLoggedInEvent.php
@@ -5,9 +5,9 @@ namespace App\Events\Frontend\Auth;
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserEmailConfirmed.
+ * Class UserLoggedInEvent.
  */
-class UserEmailConfirmed
+class UserLoggedInEvent
 {
     use SerializesModels;
 

--- a/app/Events/Frontend/Auth/UserLoggedOutEvent.php
+++ b/app/Events/Frontend/Auth/UserLoggedOutEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Backend\Access\User;
+namespace App\Events\Frontend\Auth;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserCreated.
+ * Class UserLoggedOutEvent.
  */
-class UserCreated
+class UserLoggedOutEvent
 {
     use SerializesModels;
 

--- a/app/Events/Frontend/Auth/UserRegisteredEvent.php
+++ b/app/Events/Frontend/Auth/UserRegisteredEvent.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace App\Events\Backend\Access\User;
+namespace App\Events\Frontend\Auth;
 
 use Illuminate\Queue\SerializesModels;
 
 /**
- * Class UserDeleted.
+ * Class UserRegisteredEvent.
  */
-class UserDeleted
+class UserRegisteredEvent
 {
     use SerializesModels;
 

--- a/app/Http/Controllers/Frontend/Auth/LoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/LoginController.php
@@ -7,8 +7,8 @@ use Illuminate\Http\Request;
 use App\Exceptions\GeneralException;
 use App\Http\Controllers\Controller;
 use App\Helpers\Frontend\Auth\Socialite;
-use App\Events\Frontend\Auth\UserLoggedIn;
-use App\Events\Frontend\Auth\UserLoggedOut;
+use App\Events\Frontend\Auth\UserLoggedInEvent;
+use App\Events\Frontend\Auth\UserLoggedOutEvent;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
 
 /**
@@ -60,7 +60,7 @@ class LoginController extends Controller
             throw new GeneralException(trans('exceptions.frontend.auth.deactivated'));
         }
 
-        event(new UserLoggedIn($user));
+        event(new UserLoggedInEvent($user));
 
         return redirect()->intended($this->redirectPath());
     }
@@ -93,7 +93,7 @@ class LoginController extends Controller
         /*
          * Fire event, Log out user, Redirect
          */
-        event(new UserLoggedOut($this->guard()->user()));
+        event(new UserLoggedOutEvent($this->guard()->user()));
 
         /*
          * Laravel specific logic

--- a/app/Http/Controllers/Frontend/Auth/RegisterController.php
+++ b/app/Http/Controllers/Frontend/Auth/RegisterController.php
@@ -3,8 +3,8 @@
 namespace App\Http\Controllers\Frontend\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Events\Frontend\Auth\UserRegistered;
 use Illuminate\Foundation\Auth\RegistersUsers;
+use App\Events\Frontend\Auth\UserRegisteredEvent;
 use App\Http\Requests\Frontend\Auth\RegisterRequest;
 use App\Repositories\Frontend\Access\User\UserRepository;
 
@@ -52,12 +52,12 @@ class RegisterController extends Controller
     {
         if (config('access.users.confirm_email')) {
             $user = $this->user->create($request->only('first_name', 'last_name', 'email', 'password'));
-            event(new UserRegistered($user));
+            event(new UserRegisteredEvent($user));
 
             return redirect($this->redirectPath())->withFlashSuccess(trans('exceptions.frontend.auth.confirmation.created_confirm'));
         } else {
             access()->login($this->user->create($request->only('first_name', 'last_name', 'email', 'password')));
-            event(new UserRegistered(access()->user()));
+            event(new UserRegisteredEvent(access()->user()));
 
             return redirect($this->redirectPath());
         }

--- a/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
+++ b/app/Http/Controllers/Frontend/Auth/SocialLoginController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use App\Exceptions\GeneralException;
 use App\Http\Controllers\Controller;
 use Laravel\Socialite\Facades\Socialite;
-use App\Events\Frontend\Auth\UserLoggedIn;
+use App\Events\Frontend\Auth\UserLoggedInEvent;
 use App\Repositories\Frontend\Access\User\UserRepository;
 use App\Helpers\Frontend\Auth\Socialite as SocialiteHelper;
 
@@ -84,7 +84,7 @@ class SocialLoginController extends Controller
         access()->login($user, true);
 
         // Throw an event in case you want to do anything when the user logs in
-        event(new UserLoggedIn($user));
+        event(new UserLoggedInEvent($user));
 
         // Set session variable so we know which provider user is logged in as, if ever needed
         session([config('access.socialite_session_name') => $provider]);

--- a/app/Listeners/Backend/Access/Role/RoleEventListener.php
+++ b/app/Listeners/Backend/Access/Role/RoleEventListener.php
@@ -59,17 +59,17 @@ class RoleEventListener
     public function subscribe($events)
     {
         $events->listen(
-            \App\Events\Backend\Access\Role\RoleCreated::class,
+            \App\Events\Backend\Access\Role\RoleCreatedEvent::class,
             'App\Listeners\Backend\Access\Role\RoleEventListener@onCreated'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\Role\RoleUpdated::class,
+            \App\Events\Backend\Access\Role\RoleUpdatedEvent::class,
             'App\Listeners\Backend\Access\Role\RoleEventListener@onUpdated'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\Role\RoleDeleted::class,
+            \App\Events\Backend\Access\Role\RoleDeletedEvent::class,
             'App\Listeners\Backend\Access\Role\RoleEventListener@onDeleted'
         );
     }

--- a/app/Listeners/Backend/Access/User/UserEventListener.php
+++ b/app/Listeners/Backend/Access/User/UserEventListener.php
@@ -162,42 +162,42 @@ class UserEventListener
     public function subscribe($events)
     {
         $events->listen(
-            \App\Events\Backend\Access\User\UserCreated::class,
+            \App\Events\Backend\Access\User\UserCreatedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onCreated'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserUpdated::class,
+            \App\Events\Backend\Access\User\UserUpdatedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onUpdated'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserDeleted::class,
+            \App\Events\Backend\Access\User\UserDeletedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onDeleted'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserRestored::class,
+            \App\Events\Backend\Access\User\UserRestoredEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onRestored'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserPermanentlyDeleted::class,
+            \App\Events\Backend\Access\User\UserPermanentlyDeletedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onPermanentlyDeleted'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserPasswordChanged::class,
+            \App\Events\Backend\Access\User\UserPasswordChangedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onPasswordChanged'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserDeactivated::class,
+            \App\Events\Backend\Access\User\UserDeactivatedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onDeactivated'
         );
 
         $events->listen(
-            \App\Events\Backend\Access\User\UserReactivated::class,
+            \App\Events\Backend\Access\User\UserReactivatedEvent::class,
             'App\Listeners\Backend\Access\User\UserEventListener@onReactivated'
         );
     }

--- a/app/Listeners/Frontend/Auth/UserEventListener.php
+++ b/app/Listeners/Frontend/Auth/UserEventListener.php
@@ -47,22 +47,22 @@ class UserEventListener
     public function subscribe($events)
     {
         $events->listen(
-            \App\Events\Frontend\Auth\UserLoggedIn::class,
+            \App\Events\Frontend\Auth\UserLoggedInEvent::class,
             'App\Listeners\Frontend\Auth\UserEventListener@onLoggedIn'
         );
 
         $events->listen(
-            \App\Events\Frontend\Auth\UserLoggedOut::class,
+            \App\Events\Frontend\Auth\UserLoggedOutEvent::class,
             'App\Listeners\Frontend\Auth\UserEventListener@onLoggedOut'
         );
 
         $events->listen(
-            \App\Events\Frontend\Auth\UserRegistered::class,
+            \App\Events\Frontend\Auth\UserRegisteredEvent::class,
             'App\Listeners\Frontend\Auth\UserEventListener@onRegistered'
         );
 
         $events->listen(
-            \App\Events\Frontend\Auth\UserEmailConfirmed::class,
+            \App\Events\Frontend\Auth\UserEmailConfirmedEvent::class,
             'App\Listeners\Frontend\Auth\UserEventListener@onEmailConfirmed'
         );
     }

--- a/app/Repositories/Backend/Access/Role/RoleRepository.php
+++ b/app/Repositories/Backend/Access/Role/RoleRepository.php
@@ -7,9 +7,9 @@ use Illuminate\Support\Facades\DB;
 use App\Exceptions\GeneralException;
 use App\Repositories\BaseRepository;
 use Illuminate\Database\Eloquent\Model;
-use App\Events\Backend\Access\Role\RoleCreated;
-use App\Events\Backend\Access\Role\RoleDeleted;
-use App\Events\Backend\Access\Role\RoleUpdated;
+use App\Events\Backend\Access\Role\RoleCreatedEvent;
+use App\Events\Backend\Access\Role\RoleDeletedEvent;
+use App\Events\Backend\Access\Role\RoleUpdatedEvent;
 
 /**
  * Class RoleRepository.
@@ -102,7 +102,7 @@ class RoleRepository extends BaseRepository
                     $role->attachPermissions($permissions);
                 }
 
-                event(new RoleCreated($role));
+                event(new RoleCreatedEvent($role));
 
                 return true;
             }
@@ -169,7 +169,7 @@ class RoleRepository extends BaseRepository
                     $role->attachPermissions($permissions);
                 }
 
-                event(new RoleUpdated($role));
+                event(new RoleUpdatedEvent($role));
 
                 return true;
             }
@@ -202,7 +202,7 @@ class RoleRepository extends BaseRepository
             $role->permissions()->sync([]);
 
             if ($role->delete()) {
-                event(new RoleDeleted($role));
+                event(new RoleDeletedEvent($role));
 
                 return true;
             }

--- a/app/Repositories/Backend/Access/User/UserRepository.php
+++ b/app/Repositories/Backend/Access/User/UserRepository.php
@@ -7,15 +7,15 @@ use Illuminate\Support\Facades\DB;
 use App\Exceptions\GeneralException;
 use App\Repositories\BaseRepository;
 use Illuminate\Database\Eloquent\Model;
-use App\Events\Backend\Access\User\UserCreated;
-use App\Events\Backend\Access\User\UserDeleted;
-use App\Events\Backend\Access\User\UserUpdated;
-use App\Events\Backend\Access\User\UserRestored;
-use App\Events\Backend\Access\User\UserDeactivated;
-use App\Events\Backend\Access\User\UserReactivated;
-use App\Events\Backend\Access\User\UserPasswordChanged;
+use App\Events\Backend\Access\User\UserCreatedEvent;
+use App\Events\Backend\Access\User\UserDeletedEvent;
+use App\Events\Backend\Access\User\UserUpdatedEvent;
+use App\Events\Backend\Access\User\UserRestoredEvent;
+use App\Events\Backend\Access\User\UserDeactivatedEvent;
+use App\Events\Backend\Access\User\UserReactivatedEvent;
 use App\Repositories\Backend\Access\Role\RoleRepository;
-use App\Events\Backend\Access\User\UserPermanentlyDeleted;
+use App\Events\Backend\Access\User\UserPasswordChangedEvent;
+use App\Events\Backend\Access\User\UserPermanentlyDeletedEvent;
 
 /**
  * Class UserRepository.
@@ -128,7 +128,7 @@ class UserRepository extends BaseRepository
                 //Attach new roles
                 $user->attachRoles($roles['assignees_roles']);
 
-                event(new UserCreated($user));
+                event(new UserCreatedEvent($user));
 
                 return true;
             }
@@ -162,7 +162,7 @@ class UserRepository extends BaseRepository
                 $this->checkUserRolesCount($roles);
                 $this->flushRoles($roles, $user);
 
-                event(new UserUpdated($user));
+                event(new UserUpdatedEvent($user));
 
                 return true;
             }
@@ -184,7 +184,7 @@ class UserRepository extends BaseRepository
         $user->password = bcrypt($input['password']);
 
         if ($user->save()) {
-            event(new UserPasswordChanged($user));
+            event(new UserPasswordChangedEvent($user));
 
             return true;
         }
@@ -210,7 +210,7 @@ class UserRepository extends BaseRepository
         }
 
         if ($user->delete()) {
-            event(new UserDeleted($user));
+            event(new UserDeletedEvent($user));
 
             return true;
         }
@@ -231,7 +231,7 @@ class UserRepository extends BaseRepository
 
         DB::transaction(function () use ($user) {
             if ($user->forceDelete()) {
-                event(new UserPermanentlyDeleted($user));
+                event(new UserPermanentlyDeletedEvent($user));
 
                 return true;
             }
@@ -254,7 +254,7 @@ class UserRepository extends BaseRepository
         }
 
         if ($user->restore()) {
-            event(new UserRestored($user));
+            event(new UserRestoredEvent($user));
 
             return true;
         }
@@ -280,11 +280,11 @@ class UserRepository extends BaseRepository
 
         switch ($status) {
             case 0:
-                event(new UserDeactivated($user));
+                event(new UserDeactivatedEvent($user));
             break;
 
             case 1:
-                event(new UserReactivated($user));
+                event(new UserReactivatedEvent($user));
             break;
         }
 

--- a/app/Repositories/Frontend/Access/User/UserRepository.php
+++ b/app/Repositories/Frontend/Access/User/UserRepository.php
@@ -8,8 +8,8 @@ use App\Exceptions\GeneralException;
 use App\Repositories\BaseRepository;
 use Illuminate\Support\Facades\Hash;
 use App\Models\Access\User\SocialLogin;
-use App\Events\Backend\Access\User\UserCreated;
-use App\Events\Frontend\Auth\UserEmailConfirmed;
+use App\Events\Backend\Access\User\UserCreatedEvent;
+use App\Events\Frontend\Auth\UserEmailConfirmedEvent;
 use App\Repositories\Backend\Access\Role\RoleRepository;
 use App\Notifications\Frontend\Auth\VerifyEmailNotification;
 
@@ -121,7 +121,7 @@ class UserRepository extends BaseRepository
             }
         });
 
-        event(new UserCreated($user));
+        event(new UserCreatedEvent($user));
 
         /*
          * Return the user object
@@ -205,7 +205,7 @@ class UserRepository extends BaseRepository
         if ($user->email_verification_code == $token) {
             $user->email_verified = 1;
 
-            event(new UserEmailConfirmed($user));
+            event(new UserEmailConfirmedEvent($user));
 
             return $user->save();
         }

--- a/tests/Backend/Forms/Access/RoleFormTest.php
+++ b/tests/Backend/Forms/Access/RoleFormTest.php
@@ -4,9 +4,9 @@ use Tests\BrowserKitTestCase;
 use App\Models\Access\Role\Role;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
-use App\Events\Backend\Access\Role\RoleCreated;
-use App\Events\Backend\Access\Role\RoleDeleted;
-use App\Events\Backend\Access\Role\RoleUpdated;
+use App\Events\Backend\Access\Role\RoleCreatedEvent;
+use App\Events\Backend\Access\Role\RoleDeletedEvent;
+use App\Events\Backend\Access\Role\RoleUpdatedEvent;
 
 /**
  * Class RoleFormTest.
@@ -53,7 +53,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->see('The role was successfully created.')
              ->seeInDatabase(config('access.roles_table'), ['name' => 'Test Role', 'all' => 1, 'sort' => 999]);
 
-        Event::assertDispatched(RoleCreated::class);
+        Event::assertDispatched(RoleCreatedEvent::class);
     }
 
     public function testCreateRoleFormSpecificPermissions()
@@ -73,7 +73,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->seeInDatabase(config('access.roles_table'), ['name' => 'Test Role', 'all' => 0])
              ->seeInDatabase(config('access.permission_role_table'), ['permission_id' => 1, 'role_id' => 4]);
 
-        Event::assertDispatched(RoleCreated::class);
+        Event::assertDispatched(RoleCreatedEvent::class);
     }
 
     public function testRoleAlreadyExists()
@@ -123,7 +123,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->see('The role was successfully updated.')
              ->seeInDatabase(config('access.roles_table'), ['id' => 1, 'name' => 'Administrator Edited', 'sort' => 123]);
 
-        Event::assertDispatched(RoleUpdated::class);
+        Event::assertDispatched(RoleUpdatedEvent::class);
     }
 
     public function testUpdateRoleFormSpecificPermissions()
@@ -140,7 +140,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->see('The role was successfully updated.')
              ->seeInDatabase(config('access.permission_role_table'), ['permission_id' => 1, 'role_id' => 3]);
 
-        Event::assertDispatched(RoleUpdated::class);
+        Event::assertDispatched(RoleUpdatedEvent::class);
     }
 
     public function testUpdateRoleRequiresPermission()
@@ -168,7 +168,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->notSeeInDatabase(config('access.roles_table'), ['id' => $role->id])
              ->seeInSession(['flash_success' => 'The role was successfully deleted.']);
 
-        Event::assertDispatched(RoleDeleted::class);
+        Event::assertDispatched(RoleDeletedEvent::class);
     }
 
     public function testDeleteRoleWithPermissions()
@@ -187,7 +187,7 @@ class RoleFormTest extends BrowserKitTestCase
              ->notSeeInDatabase(config('access.permission_role_table'), ['permission_id' => 1, 'role_id' => 2])
              ->seeInSession(['flash_success' => 'The role was successfully deleted.']);
 
-        Event::assertDispatched(RoleDeleted::class);
+        Event::assertDispatched(RoleDeletedEvent::class);
     }
 
     public function testCanNotDeleteAdministratorRole()

--- a/tests/Backend/Forms/Access/UserFormTest.php
+++ b/tests/Backend/Forms/Access/UserFormTest.php
@@ -3,10 +3,10 @@
 use Tests\BrowserKitTestCase;
 use App\Models\Access\User\User;
 use Illuminate\Support\Facades\Event;
-use App\Events\Backend\Access\User\UserCreated;
-use App\Events\Backend\Access\User\UserDeleted;
-use App\Events\Backend\Access\User\UserUpdated;
-use App\Events\Backend\Access\User\UserPasswordChanged;
+use App\Events\Backend\Access\User\UserCreatedEvent;
+use App\Events\Backend\Access\User\UserDeletedEvent;
+use App\Events\Backend\Access\User\UserUpdatedEvent;
+use App\Events\Backend\Access\User\UserPasswordChangedEvent;
 
 /**
  * Class UserFormTest.
@@ -42,7 +42,7 @@ class UserFormTest extends BrowserKitTestCase
              ->see('The password confirmation does not match.');
     }
 
-    public function testCreateUserEmailConfirmedForm()
+    public function testCreateUserEmailConfirmedEventForm()
     {
         // Make sure our events are fired
         Event::fake();
@@ -79,7 +79,7 @@ class UserFormTest extends BrowserKitTestCase
              ->seeInDatabase(config('access.role_user_table'), ['user_id' => 4, 'role_id' => 2])
              ->seeInDatabase(config('access.role_user_table'), ['user_id' => 4, 'role_id' => 3]);
 
-        Event::assertDispatched(UserCreated::class);
+        Event::assertDispatched(UserCreatedEvent::class);
     }
 
     public function testCreateUserUnVerifiedForm()
@@ -122,7 +122,7 @@ class UserFormTest extends BrowserKitTestCase
         // Get the user that was inserted into the database
         $user = User::where('email', $email)->first();
 
-        Event::assertDispatched(UserCreated::class);
+        Event::assertDispatched(UserCreatedEvent::class);
     }
 
     public function testCreateUserFailsIfEmailExists()
@@ -184,7 +184,7 @@ class UserFormTest extends BrowserKitTestCase
              ->seeInDatabase(config('access.role_user_table'), ['user_id' => $this->user->id, 'role_id' => 2])
              ->notSeeInDatabase(config('access.role_user_table'), ['user_id' => $this->user->id, 'role_id' => 3]);
 
-        Event::assertDispatched(UserUpdated::class);
+        Event::assertDispatched(UserUpdatedEvent::class);
     }
 
     public function testDeleteUserForm()
@@ -197,7 +197,7 @@ class UserFormTest extends BrowserKitTestCase
              ->assertRedirectedTo('/admin/access/user/deleted')
              ->notSeeInDatabase(config('access.users_table'), ['id' => $this->user->id, 'deleted_at' => null]);
 
-        Event::assertDispatched(UserDeleted::class);
+        Event::assertDispatched(UserDeletedEvent::class);
     }
 
     public function testUserCanNotDeleteSelf()
@@ -238,7 +238,7 @@ class UserFormTest extends BrowserKitTestCase
              ->seePageIs('/admin/access/user')
              ->see('The user\'s password was successfully updated.');
 
-        Event::assertDispatched(UserPasswordChanged::class);
+        Event::assertDispatched(UserPasswordChangedEvent::class);
     }
 
     public function testChangeUserPasswordDoNotMatch()

--- a/tests/Backend/Routes/Access/UserRouteTest.php
+++ b/tests/Backend/Routes/Access/UserRouteTest.php
@@ -3,11 +3,11 @@
 use Carbon\Carbon;
 use Tests\BrowserKitTestCase;
 use Illuminate\Support\Facades\Event;
-use App\Events\Backend\Access\User\UserRestored;
-use App\Events\Backend\Access\User\UserDeactivated;
-use App\Events\Backend\Access\User\UserReactivated;
-use App\Events\Backend\Access\User\UserPermanentlyDeleted;
+use App\Events\Backend\Access\User\UserRestoredEvent;
+use App\Events\Backend\Access\User\UserDeactivatedEvent;
+use App\Events\Backend\Access\User\UserReactivatedEvent;
 use App\Notifications\Frontend\Auth\VerifyEmailNotification;
+use App\Events\Backend\Access\User\UserPermanentlyDeletedEvent;
 
 /**
  * Class UserRouteTest.
@@ -117,8 +117,8 @@ class UserRouteTest extends BrowserKitTestCase
              ->see('The user was successfully updated.')
              ->seeInDatabase(config('access.users_table'), ['id' => $this->user->id, 'status' => 1]);
 
-        Event::assertDispatched(UserDeactivated::class);
-        Event::assertDispatched(UserReactivated::class);
+        Event::assertDispatched(UserDeactivatedEvent::class);
+        Event::assertDispatched(UserReactivatedEvent::class);
     }
 
     public function testRestoreUser()
@@ -136,7 +136,7 @@ class UserRouteTest extends BrowserKitTestCase
              ->see('The user was successfully restored.')
              ->seeInDatabase(config('access.users_table'), ['id' => $this->user->id, 'deleted_at' => null]);
 
-        Event::assertDispatched(UserRestored::class);
+        Event::assertDispatched(UserRestoredEvent::class);
     }
 
     public function testUserIsDeletedBeforeBeingRestored()
@@ -163,7 +163,7 @@ class UserRouteTest extends BrowserKitTestCase
              ->see('The user was deleted permanently.')
              ->notSeeInDatabase(config('access.users_table'), ['id' => $this->user->id]);
 
-        Event::assertDispatched(UserPermanentlyDeleted::class);
+        Event::assertDispatched(UserPermanentlyDeletedEvent::class);
     }
 
     public function testUserIsDeletedBeforeBeingPermanentlyDeleted()

--- a/tests/Frontend/Forms/LoggedOutFormTest.php
+++ b/tests/Frontend/Forms/LoggedOutFormTest.php
@@ -5,9 +5,9 @@ use App\Models\Access\User\User;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
-use App\Events\Frontend\Auth\UserLoggedIn;
-use App\Events\Frontend\Auth\UserRegistered;
 use Illuminate\Support\Facades\Notification;
+use App\Events\Frontend\Auth\UserLoggedInEvent;
+use App\Events\Frontend\Auth\UserRegisteredEvent;
 use App\Notifications\Frontend\Auth\PasswordResetNotification;
 
 /**
@@ -89,7 +89,7 @@ class LoggedOutFormTest extends BrowserKitTestCase
                      ]);
         }
 
-        Event::assertDispatched(UserRegistered::class);
+        Event::assertDispatched(UserRegisteredEvent::class);
     }
 
     /**
@@ -136,7 +136,7 @@ class LoggedOutFormTest extends BrowserKitTestCase
              ->see($this->admin->name)
              ->see('Access Management');
 
-        Event::assertDispatched(UserLoggedIn::class);
+        Event::assertDispatched(UserLoggedInEvent::class);
     }
 
     /**

--- a/tests/Frontend/Routes/LoggedInRouteTest.php
+++ b/tests/Frontend/Routes/LoggedInRouteTest.php
@@ -2,7 +2,7 @@
 
 use Tests\BrowserKitTestCase;
 use Illuminate\Support\Facades\Event;
-use App\Events\Frontend\Auth\UserLoggedOut;
+use App\Events\Frontend\Auth\UserLoggedOutEvent;
 
 /**
  * Class LoggedInRouteTest.
@@ -61,6 +61,6 @@ class LoggedInRouteTest extends BrowserKitTestCase
 
         $this->actingAs($this->user)->visit('/logout')->see('Login')->see('Register');
 
-        Event::assertDispatched(UserLoggedOut::class);
+        Event::assertDispatched(UserLoggedOutEvent::class);
     }
 }

--- a/tests/Frontend/Routes/LoggedOutRouteTest.php
+++ b/tests/Frontend/Routes/LoggedOutRouteTest.php
@@ -5,7 +5,7 @@ use App\Models\Access\User\User;
 use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Notification;
-use App\Events\Frontend\Auth\UserEmailConfirmed;
+use App\Events\Frontend\Auth\UserEmailConfirmedEvent;
 use App\Notifications\Frontend\Auth\VerifyEmailNotification;
 
 /**
@@ -90,7 +90,7 @@ class LoggedOutRouteTest extends BrowserKitTestCase
              ->see('Your account has been successfully confirmed!')
              ->seeInDatabase(config('access.users_table'), ['email' => $unconfirmed->email, 'email_verified' => 1]);
 
-        Event::assertDispatched(UserEmailConfirmed::class);
+        Event::assertDispatched(UserEmailConfirmedEvent::class);
     }
 
     /**


### PR DESCRIPTION
Renamed Events to include the "Event" Suffix in the Name.

This makes it more explicit when you're reading the code, and looks similar to how you would name controller in Laravel.
