### PR TITLE
Added a new event listener that fires when a User model is updated.

### DIFF
--- a/app/Events/Backend/Access/User/UserCreatedEvent.php
+++ b/app/Events/Backend/Access/User/UserCreatedEvent.php
@@ -2,6 +2,7 @@
 
 namespace App\Events\Backend\Access\User;
 
+use App\Models\Access\User\User;
 use Illuminate\Queue\SerializesModels;
 
 /**
@@ -12,7 +13,7 @@ class UserCreatedEvent
     use SerializesModels;
 
     /**
-     * @var
+     * @var User
      */
     public $user;
 

--- a/app/Listeners/Shared/Access/User/UserEventListener.php
+++ b/app/Listeners/Shared/Access/User/UserEventListener.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Listeners\Shared\Access\User;
+
+use App\Models\Access\User\User;
+use App\Notifications\Frontend\Auth\VerifyMobileNumberNotification;
+
+/**
+ * Class UserEventListener.
+ */
+class UserEventListener
+{
+    /**
+     * @param User $user
+     * @return User
+     */
+    public function checkIfMobileNumberChanged(User $user)
+    {
+        if (
+            config('access.users.confirm_mobile')
+            && $user->isDirty('mobile_number')
+        ) {
+            $user->mobile_verification_code = $user->generateMobileVerifcationCode();
+            $user->mobile_verified = false;
+            $user->notify(new VerifyMobileNumberNotification($user));
+        }
+
+        return $user;
+    }
+
+    /**
+     * Register the listeners for the subscriber.
+     *
+     * @param \Illuminate\Events\Dispatcher $events
+     */
+    public function subscribe($events)
+    {
+        $events->listen(
+            'eloquent.updating: '.User::class,
+            static::class.'@checkIfMobileNumberChanged'
+
+        );
+    }
+}

--- a/app/Models/Access/User/User.php
+++ b/app/Models/Access/User/User.php
@@ -79,7 +79,7 @@ class User extends Authenticatable
     /**
      * @return string
      */
-    private function generateMobileVerifcationCode()
+    public function generateMobileVerifcationCode()
     {
         return random_int(0, 9).random_int(0, 9).random_int(0, 9).random_int(0, 9);
     }

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -40,6 +40,12 @@ class EventServiceProvider extends ServiceProvider
          */
         \App\Listeners\Backend\Access\User\UserEventListener::class,
         \App\Listeners\Backend\Access\Role\RoleEventListener::class,
+
+        /*
+         * Shared Event Listeners (Event that can happen from both front or backend)
+         */
+        \App\Listeners\Shared\Access\User\UserEventListener::class,
+
     ];
 
     /**


### PR DESCRIPTION
This checks mobile_number has changed, if so, it invalidates the verified status of the user.
This closes Issue #9 